### PR TITLE
RecordIO interface clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,50 +18,35 @@ RecordIO is such a file format.
 ```python
 import recordio
 
-data = open('demo.recordio', 'wb')
-max_chunk_size = 1024
-writer = recordio.Writer(data, max_chunk_size)
-writer.write('abc')
-writer.write('edf')
-writer.flush()
-data.close()
+# write
+with recordio.File('demo.recordio', 'w') as rdio_w: 
+    rdio_w.write('abc')
+    rdio_w.write('def')
 ```
 
 ## Read
 
 ```python
-import recordio
+with recordio.File('demo.recordio', 'r') as rdio_r:
+    # Random access
+    for i in range(rdio_r.count()):
+        print(rdio_r.get(i))
 
-data = open('demo.recordio', 'rb')   
-index = recordio.FileIndex(data)
-print('Total file records: ' + str(index.total_records()))
+    # Range reading
+    for record in rdio_r.get_reader(2, 10):
+        print(record)
 
-for i in range(index.total_chunks()):
-  reader = recordio.Reader(data, index.chunk_offset(i))
-  print('Total chunk records: ' + str(reader.total_count()))
-
-  while reader.has_next():
-    print('record value: ' + reader.next())
-
-data.close()
+    # Direct iteration
+    for record in rdio_r:
+        print(record)
 ```
 
-## RecordIO File
-```python
-import recordio
+## Unittest
 
-# write
-rdio_w = recordio.File('demo.recordio', 'w')
-rdio_w.write('abc')
-rdio_w.write('def')
-rdio_w.close()
+In this directory:
 
-# read
-rdio_r = recordio.File('demo.recordio', 'r')
-iterator = rdio_r.iterator()       
-while iterator.has_next():
-    record = iterator.next()
-rdio_r.close()
+```bash
+python -m unittest recordio/recordio/*_test.py
 ```
 
 ## Packaging

--- a/recordio/__init__.py
+++ b/recordio/__init__.py
@@ -1,8 +1,3 @@
-from recordio.recordio.header import Header, Compressor
-from recordio.recordio.chunk import Chunk
-from recordio.recordio.file_index import FileIndex
-from recordio.recordio.writer import Writer
-from recordio.recordio.reader import RangeReader
 from recordio.recordio.file import File
 
-__all__ = ['Header', 'Chunk', 'Compressor', 'RangeReader', 'Writer', 'FileIndex', 'File']
+__all__ = ['File']

--- a/recordio/recordio/file.py
+++ b/recordio/recordio/file.py
@@ -40,9 +40,6 @@ class File(object):
 
         Returns:
           Iterator of dataset
-
-        Raises:
-          RuntimeError: wrong open mode.
         """
         return self.get_reader()
 

--- a/recordio/recordio/file.py
+++ b/recordio/recordio/file.py
@@ -14,11 +14,12 @@ class File(object):
         Raises:
           ValueError: invalid open mode input param.
         """
-        self._mode = mode
         if mode == 'r' or mode == 'read':
+            self._mode = 'r'
             self._data = open(file_path, 'rb')
             self._index = FileIndex(self._data)
         elif mode == 'w' or mode == 'write':
+            self._mode = 'w'
             self._data = open(file_path, 'wb')
             self._writer = Writer(self._data, max_chunk_size)
         else:
@@ -43,37 +44,26 @@ class File(object):
         Raises:
           RuntimeError: wrong open mode.
         """
-        if self._mode != 'r' and self._mode != 'read':
+        return self.get_reader()
+
+    def get_reader(self, start=0, end=None):
+        """Return a reader for the given range."""
+
+        if self._mode != 'r':
             raise RuntimeError('Should be under read mode')
 
-        # Starts from the first chunk
-        self._chunk_index = 0
-        # Initialize the first chunk
-        self._reader = RangeReader(self._data, self._index)
-
-        return self
-
-    def __next__(self):
-        """ For iterate operation
-
-        Returns:
-          The next value in dataset
-
-        Raises:
-          StopIteration: Reach the end of dataset
-        """
-        return next(self._reader)
+        return RangeReader(self._data, self._index, start, end)
 
     def write(self, record):
         """ Write a record into recordio file.
 
         Arguments:
           record: Record value String.
-         
+
         Raises:
           RuntimeError: wrong open mode.
         """
-        if self._mode != 'w' and self._mode != 'write':
+        if self._mode != 'w':
             raise RuntimeError('Should be under write mode')
 
         self._writer.write(record)
@@ -81,7 +71,7 @@ class File(object):
     def close(self):
         """ Close the data file
         """
-        if self._mode == 'w' or self._mode == 'write':
+        if self._mode == 'w':
             self._writer.flush()
         self._data.close()
 
@@ -97,28 +87,14 @@ class File(object):
         Raises:
           RuntimeError: wrong open mode.
         """
-        if self._mode != 'r' and self._mode != 'read':
+        if self._mode != 'r':
             raise RuntimeError('Should be under read mode')
 
-        reader = RangeReader(self._data, self._index, index, index + 1)
+        reader = self.get_reader(index, index + 1)
         try:
           return next(reader)
         except StopIteration:
           raise IndexError()
-
-    def get_index(self):
-        """ Returns the recordio file index
-
-        Returns:
-          Index of recordio file
-
-        Raises:
-          RuntimeError: wrong open mode.
-        """
-        if self._mode != 'r' and self._mode != 'read':
-            raise RuntimeError('Should be under read mode')
-
-        return self._index
 
     def count(self):
         """ Return total record count of the recordio file
@@ -129,7 +105,7 @@ class File(object):
         Raises:
           RuntimeError: wrong open mode.
         """
-        if self._mode != 'r' and self._mode != 'read':
+        if self._mode != 'r':
             raise RuntimeError('Should be under read mode')
 
         return self._index.total_records()

--- a/recordio/torch_dataset/torch_dataset_test.py
+++ b/recordio/torch_dataset/torch_dataset_test.py
@@ -1,8 +1,7 @@
 import unittest
 import tempfile
-from torch_dataset import TorchDataset 
-from recordio.recordio.file_index import FileIndex 
-from recordio.recordio.file import File
+from .torch_dataset import TorchDataset 
+from recordio import File
 
 
 class TestTorchDataset(unittest.TestCase):


### PR DESCRIPTION
recordio.file should be the only interface a client uses, this makes maintenance and evolving of the RecordIO easier. 